### PR TITLE
fix(backend): invitation service import ES module error

### DIFF
--- a/backend/src/routes/invitation.routes.ts
+++ b/backend/src/routes/invitation.routes.ts
@@ -14,7 +14,7 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { PrismaClient } from '@prisma/client';
-import { InvitationService } from '../services/invitation.service';
+import { InvitationService } from '../services/invitation.service.js';
 import { InvitationStatus } from '../types/invitation.types';
 import { validateMultiple } from '../middleware/validate.middleware';
 import { authenticate } from '../middleware/authenticate.middleware';


### PR DESCRIPTION
## Summary
- ES Modulesで必須の`.js`拡張子を`invitation.service`のインポートに追加
- Railwayデプロイ時の`ERR_MODULE_NOT_FOUND`エラーを修正

## Root Cause
Node.js ES Modulesでは、インポート文にビルド後のファイル拡張子（`.js`）を明示的に記述する必要があります。`invitation.routes.ts`のインポート文に拡張子が欠けていたため、Railwayデプロイ時にモジュールが見つからずアプリケーションが起動失敗していました。

## Changes
- `backend/src/routes/invitation.routes.ts:17`: `.js`拡張子を追加

## Test Plan
- [x] TypeScript型チェック成功
- [x] 全ユニットテスト成功（596 passed）
- [x] ビルド成功
- [x] Pre-push hooks全チェック成功

## Related Issue
Resolves Railwayデプロイ時のヘルスチェック失敗問題

🤖 Generated with [Claude Code](https://claude.com/claude-code)