### PR TITLE
fix(backend): use compiled seed.js in production environment

### DIFF
--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -48,16 +48,17 @@ elif [ "$NODE_ENV" = "production" ]; then
 fi
 
 # データベースシーディング（ロール・権限・初期管理者アカウント）
-# 開発・テスト環境: 常に実行
-# 本番環境: RUN_SEED=true で明示的にopt-in
+# 開発・テスト環境: 常に実行（TypeScriptソースから）
+# 本番環境: RUN_SEED=true で明示的にopt-in（ビルド済みJavaScriptから）
 if [ "$NODE_ENV" = "development" ] || [ "$NODE_ENV" = "test" ]; then
   echo "Running database seed..."
   npx tsx prisma/seed.ts
   echo "Seed completed successfully"
 elif [ "$NODE_ENV" = "production" ] && [ "$RUN_SEED" = "true" ]; then
   echo "Running database seed (production - explicit opt-in)..."
-  # 本番環境ではseed失敗を許容（既にデータが存在する場合など）
-  if npx tsx prisma/seed.ts; then
+  # 本番環境ではビルド済みのseed.jsを実行（dist/内のモジュール解決のため）
+  # seed失敗を許容（既にデータが存在する場合など）
+  if node dist/prisma/seed.js; then
     echo "Seed completed successfully"
   else
     echo "⚠️  Seed failed in production, but continuing startup..."


### PR DESCRIPTION
## 概要

本番環境でのシーディング実行時に、ビルド済みの `dist/prisma/seed.js` を使用するように修正しました。これにより、モジュール解決のパス問題が解決されます。

## 問題

Railway staging環境で以下のエラーが発生していました：

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/src/utils/logger.js' 
imported from /app/prisma/seed.ts
```

**原因**:
- `prisma/seed.ts` が `../src/utils/logger.js` をインポート
- 本番環境のDockerイメージには `src/` ディレクトリが存在しない（`dist/` のみ）
- `npx tsx prisma/seed.ts` を実行すると、存在しない `src/` を参照してエラー

## 解決策

### backend/docker-entrypoint.sh

**変更前**（本番環境）:
```sh
npx tsx prisma/seed.ts  # src/ を参照してエラー
```

**変更後**（本番環境）:
```sh
node dist/prisma/seed.js  # dist/src/ を正しく参照
```

### パス解決の仕組み

- `dist/prisma/seed.js` は `../src/utils/logger.js` をインポート
- `dist/prisma/` から見た `../src/` は `dist/src/` を指す（正しいパス）
- ビルド済みファイルは既に正しい相対パスを持っている

### 環境別の動作

- **開発・テスト環境**: `npx tsx prisma/seed.ts` を継続使用（`src/` が利用可能）
- **本番環境**: `node dist/prisma/seed.js` を使用（`dist/` のみ利用可能）

## 関連PR

- #71: Dockerfileをdocker-entrypoint.sh使用パターンに統一
- #67: ES Module imports に `.js` 拡張子を追加

## テスト

- ✅ フォーマットチェック通過
- ✅ 型チェック通過
- ✅ Lint通過
- ✅ ビルド成功
- ✅ セキュリティスキャン通過
- ✅ ユニットテスト通過

## Railway環境での確認事項

この修正により、以下の環境変数を設定することで、Railwayでのシーディングが正常に実行されるはずです：

- `NODE_ENV=production`
- `RUN_SEED=true`
- `MIGRATE_ON_DEPLOY=true`（マイグレーション実行用）