### PR TITLE
fix(docker): use existing node user instead of creating custom user

### DIFF
--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -6,7 +6,7 @@ ArchiTrackは、ソフトウェアプロジェクトにおけるアーキテク�
 
 Claude Codeを活用したKiro-style Spec Driven Development（スペック駆動開発）で開発されており、スラッシュコマンド、フック、エージェント機能を統合した体系的な開発ワークフローを実現しています。
 
-_最終更新: 2025-12-01（Steering Sync: Prisma 7アップグレード完了）_
+_最終更新: 2025-12-02（Steering Sync: バージョンドリフト確認完了）_
 
 ## コア機能
 

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -2,7 +2,7 @@
 
 ArchiTrackのプロジェクト構造とコーディング規約を定義します。
 
-_最終更新: 2025-12-01（Steering Sync: Prisma 7アップグレード - generated/prismaディレクトリ追加、db.ts Driver Adapter Pattern更新）_
+_最終更新: 2025-12-02（Steering Sync: Mailhogサービス追加、frontend services層確認）_
 
 ## ルートディレクトリ構成
 
@@ -623,7 +623,9 @@ backend/src/
 
 - `postgres`: PostgreSQL 15データベース（ポート5432）
 - `redis`: Redis 7キャッシュ（ポート6379）
+- `mailhog`: Mailpit（E2Eテスト用モックSMTPサーバー、ポート1025/8025）
 - `backend`: Node.js/Expressバックエンド（ポート3000）
+- `backend-prod`: 本番シミュレーション用バックエンド（ポート3001、profilesで分離）
 - `frontend`: React/Viteフロントエンド（ポート5173）
 
 **開発環境の特徴:**

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -2,7 +2,7 @@
 
 ArchiTrackは、ソフトウェアプロジェクトにおけるアーキテクチャ決定記録（ADR: Architecture Decision Record）を効率的に管理するためのWebアプリケーションです。Claude Codeを活用したKiro-style Spec Driven Developmentで開発されています。
 
-_最終更新: 2025-12-01（Steering Sync: Prisma 7アップグレード - Driver Adapter Pattern導入、@prisma/adapter-pg追加、Prisma Client出力先変更）_
+_最終更新: 2025-12-02（Steering Sync: Express 5.2.0、Vite 7.2.6、Storybook 10.1.x、Mailhogサービス追加）_
 
 ## アーキテクチャ
 
@@ -25,7 +25,7 @@ ArchiTrack/
 
 - **言語**: TypeScript 5.9.3
 - **フレームワーク**: React 19.2.0
-- **ビルドツール**: Vite 7.2.2
+- **ビルドツール**: Vite 7.2.6
 - **開発サーバー**: Vite Dev Server
 - **Webサーバー（本番）**: nginx
 - **パッケージマネージャ**: npm
@@ -55,9 +55,9 @@ ArchiTrack/
 - `jsdom` ^27.1.0 - ブラウザ環境シミュレーション
 - `@sentry/react` ^10.22.0 - Sentryエラートラッキング（Frontend）
 - `axe-playwright` ^2.2.2 - アクセシビリティ自動テスト
-- `storybook` ^10.0.8 - コンポーネントドキュメント・開発環境（**Storybook 10.x**）
+- `storybook` ^10.1.3 - コンポーネントドキュメント・開発環境（**Storybook 10.x**）
 - `@storybook/react` ^10.0.8 - Storybook React統合（**10.x系**）
-- `@storybook/react-vite` ^10.0.8 - Storybook React + Vite統合（**10.x系**）
+- `@storybook/react-vite` ^10.1.3 - Storybook React + Vite統合（**10.x系**）
 - `@storybook/test-runner` ^0.24.1 - Storybookインタラクションテスト
 - `rollup-plugin-visualizer` ^6.0.5 - バンドル分析ツール
 
@@ -89,7 +89,7 @@ ArchiTrack/
 - **言語**: TypeScript 5.9.3
 - **ランタイム**: Node.js 22
 - **開発ランタイム**: tsx 4.20.6（TypeScript実行環境）
-- **フレームワーク**: Express 5.1.0
+- **フレームワーク**: Express 5.2.0
 - **ORM**: Prisma 7.0.0（PostgreSQL用の型安全なデータアクセス、Driver Adapter Pattern）
 - **データベースクライアント**: pg (PostgreSQL) 8.11.3、@prisma/client 7.0.0、@prisma/adapter-pg 7.0.1
 - **キャッシュクライアント**: ioredis 5.3.2
@@ -106,7 +106,7 @@ ArchiTrack/
 
 ### 主要な依存関係
 
-- `express` ^5.1.0 - Webフレームワーク
+- `express` ^5.2.0 - Webフレームワーク
 - `cors` ^2.8.5 - CORS ミドルウェア
 - `helmet` ^8.1.0 - セキュリティヘッダー設定
 - `compression` ^1.8.1 - レスポンス圧縮
@@ -116,7 +116,7 @@ ArchiTrack/
 - `pg` ^8.11.3 - PostgreSQL クライアント
 - `ioredis` ^5.3.2 - Redis クライアント
 - `bull` ^4.16.5 - ジョブキュー（非同期処理）
-- `nodemailer` ^7.0.10 - メール送信
+- `nodemailer` ^7.0.11 - メール送信
 - `handlebars` ^4.7.8 - テンプレートエンジン
 - `dataloader` ^2.2.3 - データローダー（N+1問題対策）
 - `jose` ^5.10.0 - JWT EdDSA署名・検証

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,9 +21,7 @@ RUN npm run build
 # Production stage
 FROM node:22-alpine
 
-# 非rootユーザーを作成
-RUN addgroup -g 1000 -S appgroup && \
-    adduser -u 1000 -S appuser -G appgroup
+# node:22-alpineには既にnodeユーザー(UID/GID 1000)が存在するため、それを使用
 
 WORKDIR /app
 
@@ -58,10 +56,10 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 COPY scripts ./scripts
 
 # /appディレクトリの所有権を変更
-RUN chown -R appuser:appgroup /app
+RUN chown -R node:node /app
 
 # 非rootユーザーに切り替え
-USER appuser
+USER node
 
 # Railway uses PORT env variable
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary
- Docker環境でカスタムユーザーを作成する代わりに、Node.jsベースイメージに組み込まれている `node` ユーザーを使用するように修正
- これにより、Alpine LinuxとDebianベースイメージ間の互換性問題を解消
- ステアリングファイルをコードベースの現状と同期（Express 5.2.0, Vite 7.2.6, Storybook 10.1.x等）

## Changes
- `backend/Dockerfile`: カスタムユーザー作成を削除し、既存の `node` ユーザーを使用
- `.kiro/steering/`: 依存関係バージョンとサービス構成の更新

## Test plan
- [ ] `docker-compose up --build` でコンテナが正常に起動することを確認
- [ ] バックエンドコンテナ内でファイル権限が正しく設定されていることを確認
- [ ] 既存のCI/CDパイプラインが通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)