### PR TITLE
fix(docker): add dummy DATABASE_URL for prisma generate during build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,14 +6,20 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Copy Prisma schema
+# Copy Prisma schema and config
 COPY prisma ./prisma/
+COPY prisma.config.ts ./
 
 # Install all dependencies (including devDependencies for build)
 RUN npm ci
 
 # Copy source files
 COPY . .
+
+# Set dummy DATABASE_URL for prisma generate (not used for actual DB connection)
+# Prisma generate only creates client code and doesn't connect to the database
+ARG DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy?schema=public"
+ENV DATABASE_URL=${DATABASE_URL}
 
 # Generate Prisma Client and build TypeScript
 RUN npm run build
@@ -28,8 +34,9 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Copy Prisma schema and migrations for runtime
+# Copy Prisma schema, config, and migrations for runtime
 COPY prisma ./prisma/
+COPY prisma.config.ts ./
 
 # Install production dependencies only
 RUN npm ci --omit=dev && \
@@ -42,7 +49,9 @@ COPY --from=build /app/dist ./dist
 COPY --from=build /app/prisma/migrations ./prisma/migrations
 
 # Generate Prisma Client for production
-RUN npx prisma generate
+# Set dummy DATABASE_URL for prisma generate (not used for actual DB connection)
+ARG DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy?schema=public"
+RUN DATABASE_URL=${DATABASE_URL} npx prisma generate
 
 # Install tsx for running seed scripts in production
 # Note: Only needed for initial seeding when RUN_SEED=true


### PR DESCRIPTION
## Summary
- Prisma 6の`prisma.config.ts`では、`env('DATABASE_URL')`が環境変数の存在を必須とするため、Dockerビルド時にエラーが発生していた
- `prisma generate`はデータベースに実際には接続しないため、ダミーURLを使用することで問題を解決
- ビルドステージと本番ステージの両方でダミー`DATABASE_URL`を設定

## Changes
- `backend/Dockerfile`: ビルド時に`DATABASE_URL`を`ARG`/`ENV`として設定
- ビルドステージ: `prisma.config.ts`のコピーと環境変数設定を追加
- 本番ステージ: `prisma generate`実行時にダミーURLを使用

## Root Cause
Railway デプロイ時のエラー:
```
PrismaConfigEnvError: Missing required environment variable: DATABASE_URL
```

`prisma.config.ts`の`env('DATABASE_URL')`が原因で、ビルド時（DATABASE_URLが存在しない時）にprisma generateが失敗していた。

## Test Plan
- [x] ローカルでDockerビルドが成功することを確認
- [ ] Railway でデプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)