### PR TITLE
fix(ci): handle long commit messages in deployment notification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,6 +539,8 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       - name: Pre-deployment notification
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           echo "========================================="
           echo "Staging Deployment Information"
@@ -546,7 +548,7 @@ jobs:
           echo "Environment: staging"
           echo "Branch: ${{ github.ref_name }}"
           echo "Commit SHA: ${{ github.sha }}"
-          echo "Commit Message: ${{ github.event.head_commit.message }}"
+          echo "Commit Message: ${COMMIT_MSG%%$'\n'*}"
           echo "Triggered by: ${{ github.actor }}"
           echo "Timestamp: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
           echo "========================================="
@@ -719,6 +721,8 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       - name: Pre-deployment notification
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           echo "========================================="
           echo "Production Deployment Information"
@@ -726,7 +730,7 @@ jobs:
           echo "Environment: production"
           echo "Branch: ${{ github.ref_name }}"
           echo "Commit SHA: ${{ github.sha }}"
-          echo "Commit Message: ${{ github.event.head_commit.message }}"
+          echo "Commit Message: ${COMMIT_MSG%%$'\n'*}"
           echo "Triggered by: ${{ github.actor }}"
           echo "Timestamp: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
           echo "========================================="


### PR DESCRIPTION
## Summary
- CI/CDワークフローのデプロイ通知で、長いコミットメッセージによる問題を修正
- 複数行のコミットメッセージの場合、最初の行のみを表示するように変更

## Changes
- `.github/workflows/ci.yml`: staging/production両環境のPre-deployment notificationで、コミットメッセージを環境変数経由で取得し、改行以降を除去

## Test plan
- [ ] CIワークフローが正常に動作することを確認
- [ ] 複数行コミットメッセージでデプロイ通知が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)