### PR TITLE
chore(deps): bump react and react-dom from 19.2.0 to 19.2.3 in /frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,8 +12,8 @@
         "@sentry/react": "^10.32.1",
         "fabric": "^6.9.1",
         "jspdf": "^3.0.4",
-        "react": "^19.2.0",
-        "react-dom": "^19.2.0",
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3",
         "react-router-dom": "^7.9.6"
       },
       "devDependencies": {
@@ -13750,9 +13750,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
-      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
+      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -13805,16 +13805,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.0"
+        "react": "^19.2.3"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,8 +30,8 @@
     "@sentry/react": "^10.32.1",
     "fabric": "^6.9.1",
     "jspdf": "^3.0.4",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.0",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
     "react-router-dom": "^7.9.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- React と React-DOM を 19.2.0 から 19.2.3 にアップデート
- フロントエンドの依存関係の更新

## Changes
- `frontend/package.json`: react, react-dom のバージョンを更新
- `frontend/package-lock.json`: 依存関係の更新を反映

## Test plan
- [ ] フロントエンドのビルドが成功すること
- [ ] 既存のテストが通ること
- [ ] アプリケーションが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)