### PR TITLE
fix(backend): 見積依頼詳細画面の受領見積書一覧取得の権限エラーを修正

### DIFF
--- a/backend/src/__tests__/unit/routes/received-quotation.routes.test.ts
+++ b/backend/src/__tests__/unit/routes/received-quotation.routes.test.ts
@@ -274,12 +274,13 @@ describe('received-quotation.routes', () => {
       expect(response.body).toHaveLength(0);
     });
 
-    it('should require received_quotation:read permission', async () => {
+    it('should require estimate_request:read permission', async () => {
+      // 見積依頼詳細画面で受領見積書一覧を表示するため、estimate_request:read権限でアクセス可能
       mockFindByEstimateRequestId.mockResolvedValue([]);
 
       await request(app).get(`/api/estimate-requests/${estimateRequestId}/quotations`);
 
-      expect(mockRequirePermission).toHaveBeenCalledWith('received_quotation:read');
+      expect(mockRequirePermission).toHaveBeenCalledWith('estimate_request:read');
     });
   });
 

--- a/backend/src/routes/received-quotation.routes.ts
+++ b/backend/src/routes/received-quotation.routes.ts
@@ -260,7 +260,8 @@ router.post(
 router.get(
   '/',
   authenticate,
-  requirePermission('received_quotation:read'),
+  // 見積依頼詳細画面で受領見積書一覧を表示するため、estimate_request:read権限でアクセス可能とする
+  requirePermission('estimate_request:read'),
   validate(estimateRequestIdForQuotationSchema, 'params'),
   async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {


### PR DESCRIPTION
## Summary

- 見積依頼詳細画面で受領見積書一覧を取得する際の権限エラーを修正
- `/api/estimate-requests/:id/quotations` エンドポイントの権限を `received_quotation:read` から `estimate_request:read` に変更

## Background

見積依頼詳細画面では、見積依頼の詳細・項目一覧・受領見積書一覧を並列で取得しています。
しかし、受領見積書一覧取得エンドポイントが `received_quotation:read` 権限を要求していたため、
`estimate_request:read` 権限のみを持つユーザーが見積依頼詳細画面にアクセスすると403エラーが発生していました。

設計書（design.md）では見積依頼の権限（`estimate_request:*`）のみが定義されており、
見積依頼詳細画面の一部として表示される受領見積書一覧は `estimate_request:read` 権限でアクセス可能であるべきです。

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `backend/src/routes/received-quotation.routes.ts` | 受領見積書一覧取得の権限を `estimate_request:read` に変更 |
| `backend/src/__tests__/unit/routes/received-quotation.routes.test.ts` | 対応するテストを更新 |

## Test plan

- [x] ユニットテスト（received-quotation.routes.test.ts）がパスすること
- [x] 統合テストがパスすること
- [x] E2Eテスト（1138件）がすべてパスすること
- [ ] `estimate_request:read` 権限のみを持つユーザーで見積依頼詳細画面が表示できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)