### PR TITLE
chore(deps): bump @sentry/node & profiling-node to 10.51.0 + stabilize received-quotation e2e

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,7 +17,7 @@
         "@prisma/adapter-pg": "^7.3.0",
         "@prisma/client": "^7.8.0",
         "@sentry/node": "^10.51.0",
-        "@sentry/profiling-node": "^10.47.0",
+        "@sentry/profiling-node": "^10.51.0",
         "@types/bull": "^4.10.4",
         "@types/handlebars": "^4.1.0",
         "@types/multer": "^2.0.0",
@@ -3041,18 +3041,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz",
-      "integrity": "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/core": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
@@ -3127,23 +3115,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.214.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.62.0.tgz",
-      "integrity": "sha512-Tvx+vgAZKEQxU3Rx+xWLiR0mLxHwmk69/8ya04+VsV9WYh8w6Lhx5hm5yAMvo1wy0KqWgFKBLwSeo3sHCwdOww==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.214.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -3444,23 +3415,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-undici": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.24.0.tgz",
-      "integrity": "sha512-oKzZ3uvqP17sV0EsoQcJgjEfIp0kiZRbYu/eD8p13Cbahumf8lb/xpYeNr/hfAJ4owzEtIDcGIjprfLcYbIKBQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.214.0",
-        "@opentelemetry/semantic-conventions": "^1.24.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.7.0"
       }
     },
     "node_modules/@opentelemetry/redis-common": {
@@ -4420,9 +4374,9 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.47.0.tgz",
-      "integrity": "sha512-nsYRAx3EWezDut+Zl+UwwP07thh9uY7CfSAi2whTdcJl5hu1nSp2z8bba7Vq/MGbNLnazkd3A+GITBEML924JA==",
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
+      "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4512,24 +4466,6 @@
         }
       }
     },
-    "node_modules/@sentry/node-core/node_modules/@sentry/core": {
-      "version": "10.51.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
-      "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/@sentry/core": {
-      "version": "10.51.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
-      "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@sentry/opentelemetry": {
       "version": "10.51.0",
       "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.51.0.tgz",
@@ -4548,145 +4484,21 @@
         "@opentelemetry/semantic-conventions": "^1.39.0"
       }
     },
-    "node_modules/@sentry/opentelemetry/node_modules/@sentry/core": {
-      "version": "10.51.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
-      "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@sentry/profiling-node": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.47.0.tgz",
-      "integrity": "sha512-1xZNNWd5z7yR3Ljh0xlrydZXAgzrbqsHadtUca05ptbuBe8yXF5i0XK3FOMmXQGXh625ZnP+VO5fZIqSUEOwhA==",
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.51.0.tgz",
+      "integrity": "sha512-hfolAU9VfesPf0O0pXTNR9z7Cj0U6PtPnTpZg4RAEYYa73TdXqSJAYGLIiZt1F0YfGk0lIIPJTOsVTM095zt1w==",
       "license": "MIT",
       "dependencies": {
         "@sentry-internal/node-cpu-profiler": "^2.2.0",
-        "@sentry/core": "10.47.0",
-        "@sentry/node": "10.47.0"
+        "@sentry/core": "10.51.0",
+        "@sentry/node": "10.51.0"
       },
       "bin": {
         "sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/profiling-node/node_modules/@sentry/node": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.47.0.tgz",
-      "integrity": "sha512-R+btqPepv88o635G6HtVewLjqCLUedBg5HBs7Nq1qbbKvyti01uArUF2f+3DsLenk5B9LUNiRlE+frZA44Ahmw==",
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/otel": "0.18.0",
-        "@opentelemetry/api": "^1.9.1",
-        "@opentelemetry/context-async-hooks": "^2.6.1",
-        "@opentelemetry/core": "^2.6.1",
-        "@opentelemetry/instrumentation": "^0.214.0",
-        "@opentelemetry/instrumentation-amqplib": "0.61.0",
-        "@opentelemetry/instrumentation-connect": "0.57.0",
-        "@opentelemetry/instrumentation-dataloader": "0.31.0",
-        "@opentelemetry/instrumentation-express": "0.62.0",
-        "@opentelemetry/instrumentation-fs": "0.33.0",
-        "@opentelemetry/instrumentation-generic-pool": "0.57.0",
-        "@opentelemetry/instrumentation-graphql": "0.62.0",
-        "@opentelemetry/instrumentation-hapi": "0.60.0",
-        "@opentelemetry/instrumentation-http": "0.214.0",
-        "@opentelemetry/instrumentation-ioredis": "0.62.0",
-        "@opentelemetry/instrumentation-kafkajs": "0.23.0",
-        "@opentelemetry/instrumentation-knex": "0.58.0",
-        "@opentelemetry/instrumentation-koa": "0.62.0",
-        "@opentelemetry/instrumentation-lru-memoizer": "0.58.0",
-        "@opentelemetry/instrumentation-mongodb": "0.67.0",
-        "@opentelemetry/instrumentation-mongoose": "0.60.0",
-        "@opentelemetry/instrumentation-mysql": "0.60.0",
-        "@opentelemetry/instrumentation-mysql2": "0.60.0",
-        "@opentelemetry/instrumentation-pg": "0.66.0",
-        "@opentelemetry/instrumentation-redis": "0.62.0",
-        "@opentelemetry/instrumentation-tedious": "0.33.0",
-        "@opentelemetry/instrumentation-undici": "0.24.0",
-        "@opentelemetry/resources": "^2.6.1",
-        "@opentelemetry/sdk-trace-base": "^2.6.1",
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "@prisma/instrumentation": "7.6.0",
-        "@sentry/core": "10.47.0",
-        "@sentry/node-core": "10.47.0",
-        "@sentry/opentelemetry": "10.47.0",
-        "import-in-the-middle": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/profiling-node/node_modules/@sentry/node-core": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.47.0.tgz",
-      "integrity": "sha512-qv6LsqHbkQmd0aQEUox/svRSz26J+l4gGjFOUNEay2armZu9XLD+Ct89jpFgZD5oIPNAj2jraodTRqydXiwS5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.47.0",
-        "@sentry/opentelemetry": "10.47.0",
-        "import-in-the-middle": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
-        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
-        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
-        "@opentelemetry/instrumentation": ">=0.57.1 <1",
-        "@opentelemetry/resources": "^1.30.1 || ^2.1.0",
-        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
-        "@opentelemetry/semantic-conventions": "^1.39.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@opentelemetry/context-async-hooks": {
-          "optional": true
-        },
-        "@opentelemetry/core": {
-          "optional": true
-        },
-        "@opentelemetry/exporter-trace-otlp-http": {
-          "optional": true
-        },
-        "@opentelemetry/instrumentation": {
-          "optional": true
-        },
-        "@opentelemetry/resources": {
-          "optional": true
-        },
-        "@opentelemetry/sdk-trace-base": {
-          "optional": true
-        },
-        "@opentelemetry/semantic-conventions": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@sentry/profiling-node/node_modules/@sentry/opentelemetry": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.47.0.tgz",
-      "integrity": "sha512-f6Hw2lrpCjlOksiosP0Z2jK/+l+21SIdoNglVeG/sttMyx8C8ywONKh0Ha50sFsvB1VaB8n94RKzzf3hkh9V3g==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "10.47.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
-        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
-        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
-        "@opentelemetry/semantic-conventions": "^1.39.0"
       }
     },
     "node_modules/@smithy/abort-controller": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,7 +16,7 @@
         "@node-rs/argon2": "^2.0.2",
         "@prisma/adapter-pg": "^7.3.0",
         "@prisma/client": "^7.8.0",
-        "@sentry/node": "^10.47.0",
+        "@sentry/node": "^10.51.0",
         "@sentry/profiling-node": "^10.47.0",
         "@types/bull": "^4.10.4",
         "@types/handlebars": "^4.1.0",
@@ -3042,9 +3042,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.1.tgz",
-      "integrity": "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz",
+      "integrity": "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -3473,12 +3473,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
-      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/core": "2.7.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -3488,14 +3488,29 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
-      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -3503,6 +3518,21 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -4399,6 +4429,152 @@
       }
     },
     "node_modules/@sentry/node": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.51.0.tgz",
+      "integrity": "sha512-2yZLRZwS1dKG8/4eOTpGSo/gO/EgmT9aPj6lAzUkRa7bZCTTdW4BraaHU0leX5T94909Qfhbr3W5AVTfDOCKiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/otel": "0.18.0",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/core": "^2.6.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/instrumentation-amqplib": "0.61.0",
+        "@opentelemetry/instrumentation-connect": "0.57.0",
+        "@opentelemetry/instrumentation-dataloader": "0.31.0",
+        "@opentelemetry/instrumentation-fs": "0.33.0",
+        "@opentelemetry/instrumentation-generic-pool": "0.57.0",
+        "@opentelemetry/instrumentation-graphql": "0.62.0",
+        "@opentelemetry/instrumentation-hapi": "0.60.0",
+        "@opentelemetry/instrumentation-http": "0.214.0",
+        "@opentelemetry/instrumentation-ioredis": "0.62.0",
+        "@opentelemetry/instrumentation-kafkajs": "0.23.0",
+        "@opentelemetry/instrumentation-knex": "0.58.0",
+        "@opentelemetry/instrumentation-koa": "0.62.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.58.0",
+        "@opentelemetry/instrumentation-mongodb": "0.67.0",
+        "@opentelemetry/instrumentation-mongoose": "0.60.0",
+        "@opentelemetry/instrumentation-mysql": "0.60.0",
+        "@opentelemetry/instrumentation-mysql2": "0.60.0",
+        "@opentelemetry/instrumentation-pg": "0.66.0",
+        "@opentelemetry/instrumentation-redis": "0.62.0",
+        "@opentelemetry/instrumentation-tedious": "0.33.0",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@prisma/instrumentation": "7.6.0",
+        "@sentry/core": "10.51.0",
+        "@sentry/node-core": "10.51.0",
+        "@sentry/opentelemetry": "10.51.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.51.0.tgz",
+      "integrity": "sha512-VP9DMEzBEuauABrfDHYz/pRYa74M09uRJLz0ls3yel3sKhYHMyCB29ZxbKcciUhD4d33dwgi8DbaPZV2H/wnfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.51.0",
+        "@sentry/opentelemetry": "10.51.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/semantic-conventions": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/node-core/node_modules/@sentry/core": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
+      "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/core": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
+      "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.51.0.tgz",
+      "integrity": "sha512-Qc7AlCE4uhB+SvHLqah4RgR1WdY7wmmr/hx9g/prDP9R1ocshmUEMrZK9qjuwaklW7/fmkFCXI8ETxo5L1bHIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.51.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      }
+    },
+    "node_modules/@sentry/opentelemetry/node_modules/@sentry/core": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
+      "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/profiling-node": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.47.0.tgz",
+      "integrity": "sha512-1xZNNWd5z7yR3Ljh0xlrydZXAgzrbqsHadtUca05ptbuBe8yXF5i0XK3FOMmXQGXh625ZnP+VO5fZIqSUEOwhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/node-cpu-profiler": "^2.2.0",
+        "@sentry/core": "10.47.0",
+        "@sentry/node": "10.47.0"
+      },
+      "bin": {
+        "sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/profiling-node/node_modules/@sentry/node": {
       "version": "10.47.0",
       "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.47.0.tgz",
       "integrity": "sha512-R+btqPepv88o635G6HtVewLjqCLUedBg5HBs7Nq1qbbKvyti01uArUF2f+3DsLenk5B9LUNiRlE+frZA44Ahmw==",
@@ -4444,7 +4620,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@sentry/node-core": {
+    "node_modules/@sentry/profiling-node/node_modules/@sentry/node-core": {
       "version": "10.47.0",
       "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.47.0.tgz",
       "integrity": "sha512-qv6LsqHbkQmd0aQEUox/svRSz26J+l4gGjFOUNEay2armZu9XLD+Ct89jpFgZD5oIPNAj2jraodTRqydXiwS5w==",
@@ -4494,7 +4670,7 @@
         }
       }
     },
-    "node_modules/@sentry/opentelemetry": {
+    "node_modules/@sentry/profiling-node/node_modules/@sentry/opentelemetry": {
       "version": "10.47.0",
       "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.47.0.tgz",
       "integrity": "sha512-f6Hw2lrpCjlOksiosP0Z2jK/+l+21SIdoNglVeG/sttMyx8C8ywONKh0Ha50sFsvB1VaB8n94RKzzf3hkh9V3g==",
@@ -4511,23 +4687,6 @@
         "@opentelemetry/core": "^1.30.1 || ^2.1.0",
         "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
         "@opentelemetry/semantic-conventions": "^1.39.0"
-      }
-    },
-    "node_modules/@sentry/profiling-node": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.47.0.tgz",
-      "integrity": "sha512-1xZNNWd5z7yR3Ljh0xlrydZXAgzrbqsHadtUca05ptbuBe8yXF5i0XK3FOMmXQGXh625ZnP+VO5fZIqSUEOwhA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/node-cpu-profiler": "^2.2.0",
-        "@sentry/core": "10.47.0",
-        "@sentry/node": "10.47.0"
-      },
-      "bin": {
-        "sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@smithy/abort-controller": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -55,7 +55,7 @@
     "@prisma/adapter-pg": "^7.3.0",
     "@prisma/client": "^7.8.0",
     "@sentry/node": "^10.51.0",
-    "@sentry/profiling-node": "^10.47.0",
+    "@sentry/profiling-node": "^10.51.0",
     "@types/bull": "^4.10.4",
     "@types/handlebars": "^4.1.0",
     "@types/multer": "^2.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -54,7 +54,7 @@
     "@node-rs/argon2": "^2.0.2",
     "@prisma/adapter-pg": "^7.3.0",
     "@prisma/client": "^7.8.0",
-    "@sentry/node": "^10.47.0",
+    "@sentry/node": "^10.51.0",
     "@sentry/profiling-node": "^10.47.0",
     "@types/bull": "^4.10.4",
     "@types/handlebars": "^4.1.0",

--- a/e2e/specs/estimate-requests/received-quotation-dialog-improvements-e2e.spec.ts
+++ b/e2e/specs/estimate-requests/received-quotation-dialog-improvements-e2e.spec.ts
@@ -267,11 +267,13 @@ test.describe('受領見積書ダイアログ改善2 (Req 36-38, task 81.5)', ()
 
       await loginAsUser(page, 'REGULAR_USER');
 
-      // 既存の永続化値を消し、初期状態をクリーンに
-      await page.goto(`/estimate-requests/${requestId}`);
-      await page.evaluate((key) => localStorage.removeItem(key), PREVIEW_HEIGHT_STORAGE_KEY);
-
       // 1 回目: ダイアログを開く
+      // 注: 各テストは新規 BrowserContext で実行されるため localStorage は空。
+      //     かつて存在した「事前 page.goto + removeItem」は二重ナビゲーションを誘発し、
+      //     1 回目の goto が起動した /api/v1/auth/refresh のレスポンスを 2 回目の goto が
+      //     キャンセルする一方、バックエンド側ではリフレッシュトークンのローテーションが
+      //     完了してしまい、2 回目の goto に伴う refresh が 401 を返す競合が発生していた。
+      //     openReceivedQuotationCreateDialog の単一 goto に集約することで競合を回避する。
       await openReceivedQuotationCreateDialog(page, requestId);
 
       // PDFをアップロード（プレビュー領域 = リサイズ対象を出現させる）
@@ -641,29 +643,9 @@ test.describe('受領見積書ダイアログ改善2 (Req 36-38, task 81.5)', ()
       await expect(sessionDialog).toBeHidden();
     });
 
-    /**
-     * task 81.5 シナリオ5
-     *
-     * NOTE: Req 38.9（再認証モーダルの「ログイン画面へ移動」選択時の挙動）は
-     * design review Issue 1（2026-04-27, requirements.md L655）で「撤廃済み」と
-     * 明記されている。SessionExpiredModal（user-authentication/REQ-30）は連続
-     * 3 回失敗時にのみ「ログイン画面へ移動」ボタンを露出する設計のため、
-     * E2E でのカジュアルな「最初から離脱できる」シナリオとは整合しない。
-     *
-     * 本タスク仕様（task 81.5 シナリオ5）はこの撤廃前要件を前提としているため、
-     * 厳密な「ログイン画面遷移＋編集破棄」検証はバックエンドの能動的な
-     * SessionExpiredModal 失敗 3 連続シミュレーションが必要となる。
-     * その手段が現時点で利用不可なため、`test.skip` を documented reason 付きで
-     * 残し、仕様意図（要件側で撤廃済み）を将来読者に伝える。
-     */
-    test.skip('「ログイン画面へ移動」選択時に編集破棄でログイン画面遷移する (Req 38 シナリオ5: 撤廃済み)', () => {
-      // Skip reason:
-      // - requirements.md L655 で Req 38.9 は「~~削除（design review Issue 1, 2026-04-27）~~」
-      //   とマーク済み。再認証モーダルにキャンセル UI/Esc 無効化ポリシーが適用されるため、
-      //   3 回連続認証失敗フローを能動的にシミュレートしないと「ログイン画面へ移動」
-      //   ボタンが露出しない。バックエンドに失敗回数強制シミュレーション API は
-      //   未提供のため、本シナリオは現状ペンディング。
-    });
+    // task 81.5 シナリオ5 に対応していた Req 38.9 は requirements.md L655 で
+    // design review Issue 1 (2026-04-27) によって正式撤廃済みのため、対応テスト
+    // 定義は無効化（test.skip）ではなく削除する。
 
     /**
      * task 81.5 シナリオ6（仕様：「✕ ボタン」、現実：「キャンセル」ボタン）


### PR DESCRIPTION
## Summary
- `@sentry/node` を 10.47.0 → 10.51.0 に更新（Dependabot）
- `@sentry/profiling-node` を 10.47.0 → 10.51.0 に揃え、`@sentry/core` のネスト解決を単一バージョンへ収束させ `src/utils/sentry.ts:26` の TS2322（Integration 型不整合）を解消
- received-quotation ダイアログ改善 E2E の flaky を解消：Req 36 のプレビューリサイズで二重 `page.goto` がリフレッシュトークンの回転レースを誘発し 401 → `/login?sessionExpired=true` にリダイレクトしていた問題を、`openReceivedQuotationCreateDialog` ヘルパー経由の単一ナビゲーションへ統一。理由をインラインコメント化
- 公式撤回済み要件 Req 38.9（`requirements.md:655` / 2026-04-27 design review Issue 1）に対応する E2E テスト定義を削除し、テスト無効化マーカーを残さない（e2e-quality 準拠）

## Test plan
- [x] backend `type-check` / `lint` / `build` passed via pre-push hook
- [x] frontend `type-check` / `lint` / `build` passed via pre-push hook
- [x] E2E full run（pre-push）で 2042 passed / 1 flaky / 30 skipped、最終的にPASS判定
- [ ] CI（GitHub Actions）の全チェック緑を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)