### PR TITLE
fix(quantity-table): 計算用フィールドの水平スクロールとバリデーション表示崩れを修正

### DIFF
--- a/frontend/src/components/quantity-table/AutocompleteInput.test.tsx
+++ b/frontend/src/components/quantity-table/AutocompleteInput.test.tsx
@@ -291,6 +291,25 @@ describe('AutocompleteInput', () => {
       expect(input).toHaveAttribute('aria-invalid', 'true');
       expect(screen.getByText('入力してください')).toBeInTheDocument();
     });
+
+    it('エラーメッセージは吹き出し方式で表示され、フィールド下にブロック挿入されない', () => {
+      // テキストフィールド下にメッセージを挿入するとフィールド間スペースが広がり
+      // 表示が崩れるため、警告アイコン＋ホバー吹き出し（オーバーレイ）で表示する。
+      render(<AutocompleteInput {...defaultProps} id="field-x" error="入力してください" />);
+
+      const input = screen.getByRole('combobox');
+      // 入力欄がアクセシブルな説明（alert）を参照する
+      expect(input).toHaveAttribute('aria-describedby', 'field-x-error');
+
+      // 警告アイコン（アクセシブル名＝メッセージ）が入力欄内に表示される
+      expect(screen.getByRole('img', { name: '入力してください' })).toBeInTheDocument();
+
+      // メッセージは role="alert" 要素として DOM に存在する（スクリーンリーダー対応）
+      const alert = document.getElementById('field-x-error');
+      expect(alert).not.toBeNull();
+      expect(alert).toHaveAttribute('role', 'alert');
+      expect(alert).toHaveTextContent('入力してください');
+    });
   });
 
   describe('必須フィールド', () => {

--- a/frontend/src/components/quantity-table/AutocompleteInput.tsx
+++ b/frontend/src/components/quantity-table/AutocompleteInput.tsx
@@ -18,6 +18,7 @@
 
 import { useState, useRef, useCallback, useId, useEffect, useMemo } from 'react';
 import type { AutocompleteFieldName } from '../../hooks/useAutocompleteCandidateStore';
+import FieldValidationTooltip from './FieldValidationTooltip';
 
 // ============================================================================
 // 型定義
@@ -102,6 +103,8 @@ const styles = {
   inputError: {
     borderColor: '#dc2626',
     boxShadow: '0 0 0 3px rgba(220, 38, 38, 0.1)',
+    // 入力欄右端の警告アイコンと入力文字が重ならないよう余白を確保
+    paddingRight: '22px',
   } as React.CSSProperties,
   inputDisabled: {
     backgroundColor: '#f9fafb',
@@ -139,11 +142,6 @@ const styles = {
   } as React.CSSProperties,
   optionHover: {
     backgroundColor: '#f3f4f6',
-  } as React.CSSProperties,
-  errorMessage: {
-    marginTop: '4px',
-    fontSize: '12px',
-    color: '#dc2626',
   } as React.CSSProperties,
 };
 
@@ -384,6 +382,11 @@ export default function AutocompleteInput(props: AutocompleteInputProps) {
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}
         />
+        {/* バリデーションエラー（赤枠＋アイコン＋ホバー吹き出し）。
+            通常フローにメッセージを挿入しないためフィールド間スペースが崩れない。 */}
+        {error && (
+          <FieldValidationTooltip message={error} id={`${inputId}-error`} severity="error" />
+        )}
       </div>
 
       {/* ドロップダウン候補リスト */}
@@ -422,13 +425,6 @@ export default function AutocompleteInput(props: AutocompleteInputProps) {
             );
           })}
         </ul>
-      )}
-
-      {/* エラーメッセージ */}
-      {error && (
-        <div id={`${inputId}-error`} style={styles.errorMessage} role="alert">
-          {error}
-        </div>
       )}
     </div>
   );

--- a/frontend/src/components/quantity-table/EditableQuantityItemRow.tsx
+++ b/frontend/src/components/quantity-table/EditableQuantityItemRow.tsx
@@ -18,6 +18,7 @@ import type { AutocompleteFieldName } from '../../hooks/useAutocompleteCandidate
 import CalculationMethodSelect from './CalculationMethodSelect';
 import CalculationFields from './CalculationFields';
 import QuantityItemActionMenu from './QuantityItemActionMenu';
+import FieldValidationTooltip from './FieldValidationTooltip';
 import { calculate } from '../../utils/calculation-engine';
 import { QUANTITY_ITEM_GRID_COLUMNS } from './gridConstants';
 
@@ -148,11 +149,8 @@ const styles = {
   inputWarning: {
     borderColor: '#f59e0b',
     backgroundColor: '#fffbeb',
-  } as React.CSSProperties,
-  warningMessage: {
-    color: '#b45309',
-    fontSize: '11px',
-    marginTop: '2px',
+    // 入力欄右端の警告アイコンと入力文字が重ならないよう余白を確保
+    paddingRight: '22px',
   } as React.CSSProperties,
   quantityInput: {
     textAlign: 'right' as const,
@@ -563,15 +561,21 @@ export default function EditableQuantityItemRow({
                 }}
                 aria-required
                 aria-invalid={negativeQuantityWarning}
+                aria-describedby={
+                  negativeQuantityWarning ? `${item.id}-quantity-warning` : undefined
+                }
                 aria-label={showFieldLabels ? undefined : '数量'}
               />
+              {/* REQ-8.3: 負の値警告（黄枠＋アイコン＋ホバー吹き出し）。
+                  通常フローにメッセージを挿入しないため行の高さが変わらない。 */}
+              {negativeQuantityWarning && (
+                <FieldValidationTooltip
+                  message="負の値が入力されています。確認してください。"
+                  id={`${item.id}-quantity-warning`}
+                  severity="warning"
+                />
+              )}
             </div>
-            {/* REQ-8.3: 負の値警告メッセージ */}
-            {negativeQuantityWarning && (
-              <span style={styles.warningMessage} role="alert">
-                負の値が入力されています。確認してください。
-              </span>
-            )}
           </div>
         </div>
 

--- a/frontend/src/components/quantity-table/FieldValidationTooltip.stories.tsx
+++ b/frontend/src/components/quantity-table/FieldValidationTooltip.stories.tsx
@@ -48,6 +48,7 @@ function FieldWrapper({ children }: { children: React.ReactNode }) {
     <div style={{ position: 'relative', display: 'inline-block', maxWidth: '240px' }}>
       <input
         type="text"
+        aria-label="サンプル入力"
         defaultValue="入力値"
         style={{
           width: '100%',

--- a/frontend/src/components/quantity-table/FieldValidationTooltip.stories.tsx
+++ b/frontend/src/components/quantity-table/FieldValidationTooltip.stories.tsx
@@ -1,0 +1,123 @@
+/**
+ * @fileoverview FieldValidationTooltip コンポーネントのStorybook ストーリー
+ *
+ * 入力フィールド内の右端に警告アイコンを重ね、ホバー時にメッセージを
+ * 吹き出しで表示するコンポーネント。position: absolute オーバーレイのため、
+ * position: relative の入力ラッパー内に配置して確認する。
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+import FieldValidationTooltip from './FieldValidationTooltip';
+
+const meta: Meta<typeof FieldValidationTooltip> = {
+  title: 'QuantityTable/FieldValidationTooltip',
+  component: FieldValidationTooltip,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'フィールドバリデーション吹き出し。入力フィールド右端に警告アイコンを重ね、ホバー時にメッセージを吹き出し表示する。メッセージを通常フローに挿入しないためレイアウト崩れを防ぐ。',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    message: {
+      control: 'text',
+      description: '表示するメッセージ',
+    },
+    severity: {
+      control: 'select',
+      options: ['error', 'warning'],
+      description: '重要度（色の出し分け）',
+    },
+    id: {
+      control: 'text',
+      description: 'スクリーンリーダー用 alert 要素の id',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof FieldValidationTooltip>;
+
+// 入力フィールドを模した relative ラッパー（アイコン分の右パディングを確保）
+function FieldWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ position: 'relative', display: 'inline-block', maxWidth: '240px' }}>
+      <input
+        type="text"
+        defaultValue="入力値"
+        style={{
+          width: '100%',
+          padding: '6px 24px 6px 8px',
+          boxSizing: 'border-box',
+          border: '1px solid #dc2626',
+          borderRadius: '4px',
+        }}
+      />
+      {children}
+    </div>
+  );
+}
+
+/**
+ * デフォルト（error）
+ */
+export const Default: Story = {
+  render: () => (
+    <FieldWrapper>
+      <FieldValidationTooltip message="必須項目です" />
+    </FieldWrapper>
+  ),
+};
+
+/**
+ * 警告（warning）
+ */
+export const Warning: Story = {
+  render: () => (
+    <FieldWrapper>
+      <FieldValidationTooltip message="入力値を確認してください" severity="warning" />
+    </FieldWrapper>
+  ),
+};
+
+/**
+ * 長いメッセージ
+ */
+export const LongMessage: Story = {
+  render: () => (
+    <FieldWrapper>
+      <FieldValidationTooltip message="大項目は全角25文字/半角50文字以内で入力してください" />
+    </FieldWrapper>
+  ),
+};
+
+/**
+ * スクリーンリーダー用 alert 要素付き（id 指定）
+ */
+export const WithAlertId: Story = {
+  render: () => (
+    <FieldWrapper>
+      <FieldValidationTooltip message="必須項目です" id="field-error-example" />
+    </FieldWrapper>
+  ),
+};
+
+/**
+ * error / warning の比較
+ */
+export const SeverityComparison: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
+      <FieldWrapper>
+        <FieldValidationTooltip message="エラー: 必須項目です" severity="error" />
+      </FieldWrapper>
+      <FieldWrapper>
+        <FieldValidationTooltip message="警告: 値を確認してください" severity="warning" />
+      </FieldWrapper>
+    </div>
+  ),
+};

--- a/frontend/src/components/quantity-table/FieldValidationTooltip.test.tsx
+++ b/frontend/src/components/quantity-table/FieldValidationTooltip.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview フィールドバリデーション吹き出しコンポーネントのテスト
+ *
+ * 警告アイコンの表示、ホバー時の吹き出し表示、severity による色の出し分け、
+ * スクリーンリーダー用 alert 要素の出力を検証する。
+ *
+ * @module components/quantity-table/FieldValidationTooltip.test
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import FieldValidationTooltip from './FieldValidationTooltip';
+
+describe('FieldValidationTooltip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('基本レンダリング', () => {
+    it('警告アイコンが message を aria-label として表示する', () => {
+      render(<FieldValidationTooltip message="入力エラー" />);
+      const icon = screen.getByRole('img', { name: '入力エラー' });
+      expect(icon).toBeInTheDocument();
+      expect(icon).toHaveAttribute('title', '入力エラー');
+    });
+
+    it('初期状態では吹き出し（tooltip）は表示されない', () => {
+      render(<FieldValidationTooltip message="入力エラー" />);
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('ホバー時の吹き出し', () => {
+    it('マウスホバーで吹き出しが表示される', () => {
+      render(<FieldValidationTooltip message="入力エラー" />);
+      const icon = screen.getByRole('img', { name: '入力エラー' });
+
+      fireEvent.mouseEnter(icon);
+
+      const tooltip = screen.getByRole('tooltip');
+      expect(tooltip).toBeInTheDocument();
+      expect(tooltip).toHaveTextContent('入力エラー');
+    });
+
+    it('マウスが離れると吹き出しが非表示になる', () => {
+      render(<FieldValidationTooltip message="入力エラー" />);
+      const icon = screen.getByRole('img', { name: '入力エラー' });
+
+      fireEvent.mouseEnter(icon);
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+      fireEvent.mouseLeave(icon);
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('severity による色の出し分け', () => {
+    it('デフォルト（error）では赤色のアイコンを描画する', () => {
+      const { container } = render(<FieldValidationTooltip message="エラー" />);
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('stroke', '#dc2626');
+    });
+
+    it('severity="warning" では橙色のアイコンを描画する', () => {
+      const { container } = render(<FieldValidationTooltip message="警告" severity="warning" />);
+      const svg = container.querySelector('svg');
+      expect(svg).toHaveAttribute('stroke', '#b45309');
+    });
+  });
+
+  describe('スクリーンリーダー用 alert 要素', () => {
+    it('id を渡すと指定 id の alert 要素を出力する', () => {
+      render(<FieldValidationTooltip message="入力エラー" id="field-error-1" />);
+      const alert = screen.getByRole('alert');
+      expect(alert).toHaveAttribute('id', 'field-error-1');
+      expect(alert).toHaveTextContent('入力エラー');
+    });
+
+    it('id を渡さない場合は alert 要素を出力しない', () => {
+      render(<FieldValidationTooltip message="入力エラー" />);
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/quantity-table/FieldValidationTooltip.tsx
+++ b/frontend/src/components/quantity-table/FieldValidationTooltip.tsx
@@ -1,0 +1,151 @@
+/**
+ * @fileoverview フィールドバリデーション吹き出しコンポーネント
+ *
+ * 入力フィールド内の右端に警告アイコンを重ね、ホバー時にメッセージを
+ * 吹き出し（position: absolute オーバーレイ）で表示する。
+ * メッセージを通常フローに挿入しないため、フィールド間の縦スペースが
+ * 広がってレイアウトが崩れることを防ぐ。
+ *
+ * 使用側はこのコンポーネントを position: relative の入力ラッパー内に
+ * 配置し、入力欄にはアイコン分の右パディングを確保すること。
+ */
+
+import { useState } from 'react';
+
+// ============================================================================
+// 型定義
+// ============================================================================
+
+export interface FieldValidationTooltipProps {
+  /** 表示するメッセージ */
+  message: string;
+  /** スクリーンリーダー用 alert 要素の id（input の aria-describedby と対応付ける） */
+  id?: string;
+  /** 重要度（色の出し分け） */
+  severity?: 'error' | 'warning';
+}
+
+// ============================================================================
+// スタイル定義
+// ============================================================================
+
+const SEVERITY_COLOR: Record<NonNullable<FieldValidationTooltipProps['severity']>, string> = {
+  error: '#dc2626',
+  warning: '#b45309',
+};
+
+const styles = {
+  iconButton: {
+    position: 'absolute' as const,
+    top: '50%',
+    right: '4px',
+    transform: 'translateY(-50%)',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '16px',
+    height: '16px',
+    cursor: 'help',
+    zIndex: 2,
+  } as React.CSSProperties,
+  tooltip: {
+    position: 'absolute' as const,
+    bottom: 'calc(100% + 4px)',
+    right: 0,
+    backgroundColor: '#1f2937',
+    color: '#ffffff',
+    fontSize: '11px',
+    lineHeight: 1.4,
+    padding: '4px 8px',
+    borderRadius: '4px',
+    whiteSpace: 'nowrap' as const,
+    boxShadow: '0 2px 6px rgba(0, 0, 0, 0.2)',
+    zIndex: 60,
+    pointerEvents: 'none' as const,
+  } as React.CSSProperties,
+  // 視覚に影響しないスクリーンリーダー用ライブメッセージ
+  srOnly: {
+    position: 'absolute' as const,
+    width: '1px',
+    height: '1px',
+    padding: 0,
+    margin: '-1px',
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap' as const,
+    border: 0,
+  } as React.CSSProperties,
+};
+
+// ============================================================================
+// アイコン
+// ============================================================================
+
+/**
+ * 警告アイコン（三角形＋感嘆符）
+ */
+function WarningIcon({ color }: { color: string }) {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  );
+}
+
+// ============================================================================
+// メインコンポーネント
+// ============================================================================
+
+/**
+ * フィールドバリデーション吹き出し
+ *
+ * @param props - コンポーネントProps
+ */
+export default function FieldValidationTooltip({
+  message,
+  id,
+  severity = 'error',
+}: FieldValidationTooltipProps) {
+  const [isHovered, setIsHovered] = useState(false);
+  const color = SEVERITY_COLOR[severity];
+
+  return (
+    <>
+      <span
+        style={styles.iconButton}
+        role="img"
+        aria-label={message}
+        title={message}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
+        <WarningIcon color={color} />
+      </span>
+
+      {isHovered && (
+        <span role="tooltip" style={styles.tooltip}>
+          {message}
+        </span>
+      )}
+
+      {/* a11y: 視覚に影響しないライブメッセージ（input の aria-describedby が参照） */}
+      {id && (
+        <span id={id} role="alert" style={styles.srOnly}>
+          {message}
+        </span>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/quantity-table/QuantityGroupCard.test.tsx
+++ b/frontend/src/components/quantity-table/QuantityGroupCard.test.tsx
@@ -181,6 +181,29 @@ describe('QuantityGroupCard', () => {
       });
     });
 
+    describe('計算用フィールドの水平スクロール', () => {
+      it('カードが overflow-x: auto で水平スクロール可能（計算用フィールド閲覧のため）', () => {
+        // 計算方法（面積・体積/ピッチ）選択時に操作列の右へ展開する計算用フィールドを
+        // 閲覧できるよう、カードが水平スクロール可能であること。
+        // 従来は overflow: hidden でクリップされ追加フィールドへ到達できなかった。
+        renderWithRouter(
+          <QuantityGroupCard group={mockGroupWithImage} groupDisplayName="テストグループ" />
+        );
+
+        const card = screen.getByTestId('quantity-group-card');
+        expect(card).toHaveStyle({ overflowX: 'auto' });
+      });
+
+      it('カードの縦方向はクリップされ、角丸クリップとレイアウトを維持する', () => {
+        renderWithRouter(
+          <QuantityGroupCard group={mockGroupWithImage} groupDisplayName="テストグループ" />
+        );
+
+        const card = screen.getByTestId('quantity-group-card');
+        expect(card).toHaveStyle({ overflowY: 'hidden' });
+      });
+    });
+
     describe('REQ 3.3: 該当写真の注釈付きサムネイル表示', () => {
       it('紐付き画像があるグループにサムネイルが表示される', () => {
         renderWithRouter(

--- a/frontend/src/components/quantity-table/QuantityGroupCard.tsx
+++ b/frontend/src/components/quantity-table/QuantityGroupCard.tsx
@@ -105,7 +105,12 @@ const styles = {
     backgroundColor: '#ffffff',
     borderRadius: '8px',
     border: '1px solid #e5e7eb',
-    overflow: 'hidden',
+    // 計算方法（面積・体積/ピッチ）選択時に操作列の右へ展開する計算用フィールドを
+    // 閲覧できるよう、カードに水平スクロールを付与する（従来は overflow:hidden で
+    // クリップされ追加フィールドへ到達できなかった）。
+    // 縦方向は従来どおりクリップし、角丸クリップとレイアウトを維持する。
+    overflowX: 'auto' as const,
+    overflowY: 'hidden' as const,
   } as React.CSSProperties,
   header: {
     display: 'flex',


### PR DESCRIPTION
## 概要

数量表編集画面のUI不具合2件を修正し、関連するテスト・Storybookストーリー・アクセシビリティ対応を追加します。

## 背景・課題

1. **計算用フィールドの水平スクロール不可**: 計算方法（面積・体積／ピッチ）選択時に操作列の右へ展開する計算用フィールドが、グループカードの `overflow:hidden` にクリップされ閲覧できなかった。
2. **バリデーション表示崩れ**: 必須フィールドのエラーメッセージがフィールド下に挿入され、行高が伸びてフィールド間スペースが広がり表示が崩れていた。

## 変更内容

### 1. 計算用フィールドの水平スクロール対応
- `QuantityGroupCard` を `overflowX:auto` + `overflowY:hidden` に変更し、追加フィールドを水平スクロールで閲覧可能に。縦方向は従来どおりクリップし角丸・レイアウトを維持。

### 2. バリデーション表示方式の刷新（非破壊オーバーレイ化）
- 共通コンポーネント `FieldValidationTooltip` を新設。赤枠＋警告アイコン＋ホバー吹き出し（`position:absolute` オーバーレイ）方式へ変更し、通常フローにメッセージを挿入しないことでレイアウトを非破壊に。
- `AutocompleteInput` のエラー表示、`EditableQuantityItemRow` の数量欄・負の値警告を同方式へ統一。
- アクセシビリティ対応として `role="alert"` 要素と `aria-describedby` を保持。

### 3. テスト・Storybook・品質対応
- `FieldValidationTooltip` のユニットテスト（カバレッジ100%）と Storybook ストーリーを追加。
- Storybook ストーリーのスキャフォールド用 input に `aria-label` を付与し axe（WCAG 2.0 A）違反を解消。
- `AutocompleteInput` / `QuantityGroupCard` のテストを追加。

## 検証

- pre-push フックの全チェック通過（カバレッジ / Storybook網羅率100% / smoke-test / 型 / lint）
- E2E: **2079 passed / 0 failed / 35 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
