### PR TITLE
fix: Railway本番のentrypoint依存再インストール撤廃とfrontend lockfile整合

### DIFF
--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -2,7 +2,9 @@
 
 ArchiTrackは、建設プロジェクトの管理・積算業務を効率化するためのWebアプリケーションです。プロジェクト管理、現場調査、数量拾い出し、内訳書作成、見積依頼・見積書作成までの一連の業務フローをサポートします。Claude Codeを活用したKiro-style Spec Driven Developmentで開発されています。
 
-_最終更新: 2026-06-05（Steering Sync: 全Dockerfileでcorepackによるnpm版固定（packageManager `npm@11.6.2`）でnpm ci決定性を確保するパターン、backend entrypointでのsharpネイティブバイナリ自己修復パターンを反映）_
+_最終更新: 2026-06-08（Steering Sync: backend entrypointの実行時`npm ci`をdev/test限定化し本番はイメージ同梱依存を信頼するパターン（Railway永続ボリュームのroot所有node_modulesでのEACCESクラッシュループ対策）、sharp自己修復の非致命化を反映）_
+
+_2026-06-05（Steering Sync: 全Dockerfileでcorepackによるnpm版固定（packageManager `npm@11.6.2`）でnpm ci決定性を確保するパターン、backend entrypointでのsharpネイティブバイナリ自己修復パターンを反映）_
 
 _2026-06-04（Steering Sync: frontend react-router-dom を脆弱性対応で ^7.16.0 へ更新、backend Prisma 7.8.0 / @prisma/adapter-pg 7.3.0 へバージョン整合、ルートワークスペースのみ ESLint 10 系へ追従（frontend/backend は plugin 非互換のため 9 系維持）を反映）_
 
@@ -540,9 +542,9 @@ docker-compose.ci.yml    # CI環境オーバーライド（nginx本番イメー�
 - 起動時間の最適化（45-60秒 → 10-15秒）
 
 **バックエンド (`backend/docker-entrypoint.sh`):**
-- `node_modules/.bin`の存在確認
-- 不足している場合のみ依存関係をインストール
-- **sharpネイティブバイナリの自己修復**: 依存チェックは`package.json`/`package-lock.json`のハッシュ一致で`npm ci`をスキップするが、ハッシュは`node_modules`実体の健全性までは検証しない。永続ボリューム上の`node_modules`が陳腐化し実行プラットフォーム向けの`libvips`（musl）を欠くとsharpロードが失敗し、ストレージサービス初期化失敗→画像アップロードが503となる。そのため起動毎にロード可否を検証し、不可なら`npm install --no-save sharp`で現在のプラットフォーム向けに再解決して修復する（lockfileは変更しない）
+- **実行時の依存再インストール（ハッシュゲート付き`npm ci`）は dev/test 環境限定**（`NODE_ENV`で分岐）: dev/testはソースと`node_modules`をボリュームマウントするためホスト側`package*.json`変更の起動時取り込みが必要。本番はDockerfileで`npm ci --omit=dev`し`node_modules`を`node`ユーザー所有で焼き込み済みのため、起動時再インストールは行わずイメージ同梱依存を信頼する
+  - **背景**: 本番でハッシュゲートが`npm ci`を起動すると、Railway永続ボリューム上のroot所有`node_modules`を`node`ユーザーが置換できずEACCES（unlink拒否）で失敗→`set -e`によりentrypointがexec前に終了→サーバが待受せずHealthcheck失敗のクラッシュループに陥る。依存bumpで`package-lock.json`が変わった瞬間のみ顕在化していた
+- **sharpネイティブバイナリの自己修復**: 上記ハッシュゲートは`node_modules`実体の健全性までは検証しないため、永続ボリューム上の`node_modules`が陳腐化し実行プラットフォーム向けの`libvips`（musl）を欠くとsharpロードが失敗し、ストレージサービス初期化失敗→画像アップロードが503となる。そのため**全環境で**起動毎にロード可否を検証し、不可なら`npm install --no-save sharp`で現在のプラットフォーム向けに再解決して修復する（lockfileは変更しない）。**修復失敗は非致命扱い**とし、修復不能時もアプリ起動を継続する（アプリは`index.ts`でstorage/sharp初期化失敗時も起動継続する設計のため、ここでクラッシュさせるとHealthcheck失敗・クラッシュループの原因になる）
 
 #### npm版固定パターン（ビルド決定性）
 

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -25,31 +25,47 @@ wait_for_database() {
 
 echo "Checking dependencies..."
 
-# package.jsonのハッシュを計算
-CURRENT_HASH=$(sha256sum package.json package-lock.json 2>/dev/null | sha256sum | cut -d' ' -f1)
-STORED_HASH=""
+# 実行時の依存再インストール（ハッシュゲート付き npm ci）は dev/test 専用とする。
+#
+# dev/test は docker-compose でソースと node_modules をボリュームマウントするため、
+# ホスト側の package*.json 変更を起動時に取り込む必要がある。一方、本番イメージは
+# Dockerfile で `npm ci --omit=dev` を実行し node_modules を node ユーザー所有で
+# 焼き込み済みであり、実行時の再インストールは不要かつ有害である。
+#
+# 本番でこのハッシュゲートが npm ci を起動すると、Railway 永続ボリューム上の
+# root 所有 node_modules を node ユーザーが置換できず EACCES（unlink 拒否）で失敗し、
+# `set -e` により entrypoint が exec 前に終了 → サーバが listen せず Healthcheck 失敗 →
+# クラッシュループに陥る。依存 bump で package-lock.json が変わった瞬間に顕在化する。
+# そのため本番ではイメージ同梱の node_modules を信頼し、実行時 npm ci を行わない。
+if [ "$NODE_ENV" = "development" ] || [ "$NODE_ENV" = "test" ]; then
+  # package.jsonのハッシュを計算
+  CURRENT_HASH=$(sha256sum package.json package-lock.json 2>/dev/null | sha256sum | cut -d' ' -f1)
+  STORED_HASH=""
 
-if [ -f "node_modules/.package-hash" ]; then
-  STORED_HASH=$(cat node_modules/.package-hash)
-fi
+  if [ -f "node_modules/.package-hash" ]; then
+    STORED_HASH=$(cat node_modules/.package-hash)
+  fi
 
-needs_install=false
+  needs_install=false
 
-if [ ! -d "node_modules/.bin" ]; then
-  echo "node_modules is empty, installing dependencies..."
-  needs_install=true
-elif [ "$CURRENT_HASH" != "$STORED_HASH" ]; then
-  echo "package.json or package-lock.json has changed, updating dependencies..."
-  needs_install=true
+  if [ ! -d "node_modules/.bin" ]; then
+    echo "node_modules is empty, installing dependencies..."
+    needs_install=true
+  elif [ "$CURRENT_HASH" != "$STORED_HASH" ]; then
+    echo "package.json or package-lock.json has changed, updating dependencies..."
+    needs_install=true
+  else
+    echo "Dependencies are up to date"
+  fi
+
+  if [ "$needs_install" = true ]; then
+    npm ci
+    # ハッシュを保存
+    echo "$CURRENT_HASH" > node_modules/.package-hash
+    echo "Dependencies installed successfully"
+  fi
 else
-  echo "Dependencies are up to date"
-fi
-
-if [ "$needs_install" = true ]; then
-  npm ci
-  # ハッシュを保存
-  echo "$CURRENT_HASH" > node_modules/.package-hash
-  echo "Dependencies installed successfully"
+  echo "Production environment: using dependencies baked into the image (skipping runtime npm ci)"
 fi
 
 # sharp ネイティブバイナリの健全性検証と自己修復
@@ -61,9 +77,15 @@ fi
 # 不可なら現在のプラットフォーム向けに再解決して修復する
 # （--no-save により package.json / package-lock.json は変更しない）。
 if ! node -e "import('sharp').then(() => process.exit(0)).catch(() => process.exit(1))" >/dev/null 2>&1; then
-  echo "sharp native binary is missing or unloadable; repairing for current platform..."
-  npm install --no-save sharp
-  echo "sharp repaired successfully"
+  echo "sharp native binary is missing or unloadable; attempting repair for current platform..."
+  # 修復失敗で起動全体を止めない（set -e 配下でも非致命扱いにする）。
+  # アプリは storage/sharp 初期化失敗時も起動継続する設計（index.ts）であり、
+  # ここでクラッシュさせると Healthcheck 失敗・クラッシュループの原因になるため。
+  if npm install --no-save sharp; then
+    echo "sharp repaired successfully"
+  else
+    echo "⚠️  sharp repair failed; continuing startup (image features may be degraded)"
+  fi
 fi
 
 echo "Generating Prisma Client..."

--- a/docs/deployment/troubleshooting.md
+++ b/docs/deployment/troubleshooting.md
@@ -315,6 +315,49 @@ curl: (7) Failed to connect to <backend-url> port 443: Connection refused
 
 ---
 
+## ヘルスチェックが5分間 service unavailable で失敗する（起動時 npm ci の EACCES）
+
+**症状:**
+```
+Starting Container
+Checking dependencies...
+package.json or package-lock.json has changed, updating dependencies...
+npm error code EACCES
+npm error syscall unlink
+npm error path /app/node_modules/@emnapi/core/LICENSE
+...
+1/1 replicas never became healthy!
+Healthcheck failed!
+```
+- Docker イメージの build / push は成功するが、起動後 `/health` が応答せず Healthcheck が
+  タイムアウトする。直前にデプロイログで上記の `npm ci` EACCES が繰り返し出る。
+
+**原因:**
+- backend は `node` ユーザーで起動する（`Dockerfile` の `USER node`）。
+- `docker-entrypoint.sh` の依存チェックが `package-lock.json` のハッシュ変化を検知すると
+  起動時に `npm ci` を実行する。
+- `/app/node_modules` が **Railway 永続ボリューム**で、その中身が **root 所有**（過去に root
+  実行だったイメージが作成）の場合、`node` ユーザーは既存ファイルを置換できず EACCES で失敗する。
+- entrypoint は `set -e` のためサーバ起動（`exec`）に到達せず終了し、クラッシュループになる。
+- 依存 bump で `package-lock.json` が変わった瞬間に顕在化する（不変の間はハッシュ一致で
+  `npm ci` がスキップされ表面化しない）。
+
+**解決方法:**
+
+1. **`/app/node_modules` の永続ボリュームを外す（推奨・恒久対処）:**
+   - node_modules は Dockerfile の `npm ci --omit=dev` でイメージに焼き込み済みのため、
+     本番で永続化する必要はない。
+   - Railway Dashboard > Service（backend）> **Settings > Volumes** で `/app/node_modules`
+     にマウントされたボリュームを削除（Detach / Delete）し、再デプロイする。
+   - entrypoint は本番（`NODE_ENV=production`）では実行時 `npm ci` を行わず、イメージ同梱の
+     node_modules を使用する。
+
+2. **ボリュームを残す運用の場合:**
+   - ボリュームを一度削除して作り直し、`node` ユーザーが書き込める状態にする
+     （root 所有の古い node_modules を残さない）。
+
+---
+
 ## パフォーマンス関連
 
 ### アプリケーションが遅い

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -802,10 +802,33 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3460,6 +3483,17 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {


### PR DESCRIPTION
## 概要

Railway 本番環境のクラッシュループ（entrypoint の起動時 `npm ci` が root 所有 node_modules 永続ボリュームで EACCES → `set -e` で起動前終了 → Healthcheck 失敗 → 新デプロイ非昇格で旧コード配信）を解消する。あわせて pre-push の Docker ビルドを阻んでいた frontend lockfile の不整合も修正。

## 変更内容

- **fix(backend)**: 本番 entrypoint で起動時の依存再インストールを行わないようにし、`npm ci` 起因の EACCES クラッシュループを回避（dev/test 限定化）。
- **docs(steering)**: 本番 entrypoint の「依存を再インストールしない」方針を `tech.md` に反映。`docs/deployment/troubleshooting.md` に事象と対処を追記。
- **fix(frontend)**: `package-lock.json` の `@emnapi` 系 optional 依存ドリフト（`@emnapi/core`/`@emnapi/runtime` 1.11.0 欠落、`@emnapi/wasi-threads` 1.2.1→1.2.2）を `npm install --package-lock-only`(npm@11.6.2) で整合し、`node:22-alpine`(musl) の Docker ビルド `npm ci`(EUSAGE) を確定的に通るようにした。

## 検証

- pre-push フックの全品質チェックを通過（`✅ All checks passed!`）。
  - format / type-check / lint / build / 単体テスト＋カバレッジ / Storybook 網羅 100% / Docker テスト環境 / 統合・E2E。
  - E2E: 2111 passed / 35 skipped / 1 flaky（パフォーマンス計測の一覧ロード閾値、再試行で pass）。
- `docker build --target build` 単独で frontend `npm ci` 成功（1217 packages）を再現確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
