### PR TITLE
fix(ci): backendの依存インストールをnpm@11.6.2に統一し注釈ドリフトのnpm ci失敗を解消

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,10 @@ jobs:
             # resolution matches the committed lockfile (default npm 10.x rejects it with EUSAGE)
             npx -y npm@11.6.2 --prefix frontend ci
           else
-            npm --prefix ${{ matrix.workspace }} ci
+            # Pin npm to backend/package.json "packageManager" (npm@11.6.2) so npm's optional-dependency
+            # resolution matches the committed lockfile. Dependabot regenerates the backend lockfile with
+            # npm 11 (dropping nested @emnapi optional deps); default npm 10.x then rejects it with EUSAGE.
+            npx -y npm@11.6.2 --prefix ${{ matrix.workspace }} ci
           fi
       - name: Run format check
         run: |
@@ -123,7 +126,10 @@ jobs:
             # resolution matches the committed lockfile (default npm 10.x rejects it with EUSAGE)
             npx -y npm@11.6.2 --prefix frontend ci
           else
-            npm --prefix ${{ matrix.workspace }} ci
+            # Pin npm to backend/package.json "packageManager" (npm@11.6.2) so npm's optional-dependency
+            # resolution matches the committed lockfile. Dependabot regenerates the backend lockfile with
+            # npm 11 (dropping nested @emnapi optional deps); default npm 10.x then rejects it with EUSAGE.
+            npx -y npm@11.6.2 --prefix ${{ matrix.workspace }} ci
           fi
       - name: Run type check
         run: |
@@ -167,7 +173,10 @@ jobs:
             # resolution matches the committed lockfile (default npm 10.x rejects it with EUSAGE)
             npx -y npm@11.6.2 --prefix frontend ci
           else
-            npm --prefix ${{ matrix.workspace }} ci
+            # Pin npm to backend/package.json "packageManager" (npm@11.6.2) so npm's optional-dependency
+            # resolution matches the committed lockfile. Dependabot regenerates the backend lockfile with
+            # npm 11 (dropping nested @emnapi optional deps); default npm 10.x then rejects it with EUSAGE.
+            npx -y npm@11.6.2 --prefix ${{ matrix.workspace }} ci
           fi
       - name: Generate Prisma Client (backend only)
         if: matrix.workspace == 'backend'
@@ -246,7 +255,10 @@ jobs:
             # resolution matches the committed lockfile (default npm 10.x rejects it with EUSAGE)
             npx -y npm@11.6.2 --prefix frontend ci
           else
-            npm --prefix ${{ matrix.workspace }} ci
+            # Pin npm to backend/package.json "packageManager" (npm@11.6.2) so npm's optional-dependency
+            # resolution matches the committed lockfile. Dependabot regenerates the backend lockfile with
+            # npm 11 (dropping nested @emnapi optional deps); default npm 10.x then rejects it with EUSAGE.
+            npx -y npm@11.6.2 --prefix ${{ matrix.workspace }} ci
           fi
       - name: Build
         run: npm --prefix ${{ matrix.workspace }} run build
@@ -364,7 +376,7 @@ jobs:
         run: npm ci
 
       - name: Install backend dependencies
-        run: npm --prefix backend ci
+        run: npx -y npm@11.6.2 --prefix backend ci
 
       - name: Generate Prisma Client
         run: npm --prefix backend run prisma:generate
@@ -504,7 +516,7 @@ jobs:
       - name: Install root dependencies
         run: npm ci --ignore-scripts
       - name: Install backend dependencies
-        run: npm --prefix backend ci --ignore-scripts
+        run: npx -y npm@11.6.2 --prefix backend ci --ignore-scripts
       - name: Install frontend dependencies
         # Pin npm to frontend/package.json "packageManager" so npm's optional-dependency
         # resolution matches the committed lockfile (default npm 10.x rejects it with EUSAGE)
@@ -581,7 +593,7 @@ jobs:
             prisma-binaries-${{ runner.os }}-
 
       - name: Install backend dependencies
-        run: npm --prefix backend ci
+        run: npx -y npm@11.6.2 --prefix backend ci
 
       - name: Check environment variables
         run: npm --prefix backend run check:env
@@ -763,7 +775,7 @@ jobs:
             prisma-binaries-${{ runner.os }}-
 
       - name: Install backend dependencies
-        run: npm --prefix backend ci
+        run: npx -y npm@11.6.2 --prefix backend ci
 
       - name: Check environment variables
         run: npm --prefix backend run check:env

--- a/.security-audit-allowlist.json
+++ b/.security-audit-allowlist.json
@@ -2,7 +2,7 @@
   "$schema": "./schemas/security-audit-allowlist.schema.json",
   "description": "既知の脆弱性で修正版が未提供、または開発ツールのため本番に影響しないもの",
   "version": "1.0.0",
-  "lastUpdated": "2026-06-02",
+  "lastUpdated": "2026-06-15",
   "allowlist": {
     "backend": [
       {
@@ -13,10 +13,120 @@
         "expires": "2026-09-01",
         "addedBy": "claude",
         "addedDate": "2026-02-04"
+      },
+      {
+        "package": "esbuild",
+        "severity": "high",
+        "reason": "開発専用バンドラ。esbuildのdevサーバが任意ファイル読取を許す (GHSA-g7r4-m6w7-qqqr)。devサーバはローカル開発時のみ起動し、CIビルド・本番ランタイムには到達しないため影響なし。非破壊の修正版あり (fixAvailable=true) のため次回dependabot bumpで解消予定。それまで暫定許容。",
+        "reference": "https://github.com/advisories/GHSA-g7r4-m6w7-qqqr",
+        "expires": "2026-07-15",
+        "addedBy": "claude",
+        "addedDate": "2026-06-15"
+      },
+      {
+        "package": "tsx",
+        "severity": "high",
+        "reason": "開発専用のTypeScript実行ツール。内包するesbuild経由の脆弱性 (GHSA-g7r4-m6w7-qqqr)。ローカル開発時のみ使用し本番・CIランタイムに影響なし。非破壊の修正版あり (fixAvailable=true) のため次回dependabot bumpで解消予定。",
+        "reference": "https://github.com/advisories/GHSA-g7r4-m6w7-qqqr",
+        "expires": "2026-07-15",
+        "addedBy": "claude",
+        "addedDate": "2026-06-15"
       }
     ],
-    "frontend": [],
-    "root": []
+    "frontend": [
+      {
+        "package": "storybook",
+        "severity": "high",
+        "reason": "開発専用UIカタログ。esbuild devサーバ経由の脆弱性 (GHSA-g7r4-m6w7-qqqr)。Storybookはローカル開発・Storybookテスト時のみ使用し本番バンドルに含まれない。修正には storybook v8.6.18 系への破壊的ダウングレード (現行v10) が必要なため、メジャー更新まで暫定許容。",
+        "reference": "https://github.com/advisories/GHSA-g7r4-m6w7-qqqr",
+        "expires": "2026-09-01",
+        "addedBy": "claude",
+        "addedDate": "2026-06-15"
+      },
+      {
+        "package": "@storybook/builder-vite",
+        "severity": "high",
+        "reason": "開発専用Storybookビルダ。esbuild devサーバ経由の脆弱性 (GHSA-g7r4-m6w7-qqqr)。本番バンドル非対象。修正は storybook v8.6.18 系への破壊的変更が必要なため暫定許容。",
+        "reference": "https://github.com/advisories/GHSA-g7r4-m6w7-qqqr",
+        "expires": "2026-09-01",
+        "addedBy": "claude",
+        "addedDate": "2026-06-15"
+      },
+      {
+        "package": "@storybook/csf-plugin",
+        "severity": "high",
+        "reason": "開発専用Storybookプラグイン。esbuild devサーバ経由の脆弱性 (GHSA-g7r4-m6w7-qqqr)。本番バンドル非対象。修正は storybook v8.6.18 系への破壊的変更が必要なため暫定許容。",
+        "reference": "https://github.com/advisories/GHSA-g7r4-m6w7-qqqr",
+        "expires": "2026-09-01",
+        "addedBy": "claude",
+        "addedDate": "2026-06-15"
+      },
+      {
+        "package": "@storybook/react",
+        "severity": "high",
+        "reason": "開発専用StorybookのReactレンダラ。esbuild devサーバ経由の脆弱性 (GHSA-g7r4-m6w7-qqqr)。本番バンドル非対象。修正は storybook v8.6.18 系への破壊的変更が必要なため暫定許容。",
+        "reference": "https://github.com/advisories/GHSA-g7r4-m6w7-qqqr",
+        "expires": "2026-09-01",
+        "addedBy": "claude",
+        "addedDate": "2026-06-15"
+      },
+      {
+        "package": "@storybook/react-dom-shim",
+        "severity": "high",
+        "reason": "開発専用StorybookのReact DOM shim。esbuild devサーバ経由の脆弱性 (GHSA-g7r4-m6w7-qqqr)。本番バンドル非対象。修正は storybook 系メジャー更新が必要なため暫定許容。",
+        "reference": "https://github.com/advisories/GHSA-g7r4-m6w7-qqqr",
+        "expires": "2026-09-01",
+        "addedBy": "claude",
+        "addedDate": "2026-06-15"
+      },
+      {
+        "package": "@storybook/react-vite",
+        "severity": "high",
+        "reason": "開発専用StorybookのVite統合。esbuild devサーバ経由の脆弱性 (GHSA-g7r4-m6w7-qqqr)。本番バンドル非対象。修正は storybook v8.6.18 系への破壊的変更が必要なため暫定許容。",
+        "reference": "https://github.com/advisories/GHSA-g7r4-m6w7-qqqr",
+        "expires": "2026-09-01",
+        "addedBy": "claude",
+        "addedDate": "2026-06-15"
+      },
+      {
+        "package": "esbuild",
+        "severity": "high",
+        "reason": "開発専用バンドラ (Vite/Storybook経由)。devサーバが任意ファイル読取を許す (GHSA-g7r4-m6w7-qqqr)。devサーバはローカル開発時のみ起動し本番バンドル・CIには到達しない。frontendでの修正は storybook 系メジャー更新に連動するため暫定許容。",
+        "reference": "https://github.com/advisories/GHSA-g7r4-m6w7-qqqr",
+        "expires": "2026-09-01",
+        "addedBy": "claude",
+        "addedDate": "2026-06-15"
+      },
+      {
+        "package": "concurrently",
+        "severity": "critical",
+        "reason": "開発専用のnpmスクリプト並列実行ツール。内包する shell-quote 経由の脆弱性 (GHSA-w7jw-789q-3m8p)。ローカル開発スクリプトでのみ使用し本番・CIランタイムに影響なし。修正には concurrently v10 系への破壊的更新が必要なため暫定許容。",
+        "reference": "https://github.com/advisories/GHSA-w7jw-789q-3m8p",
+        "expires": "2026-09-01",
+        "addedBy": "claude",
+        "addedDate": "2026-06-15"
+      },
+      {
+        "package": "shell-quote",
+        "severity": "critical",
+        "reason": "開発専用 (concurrently経由)。quote() が改行を未エスケープ (GHSA-w7jw-789q-3m8p)。ローカル開発スクリプトでのみ使用し本番・CIランタイムに影響なし。修正は concurrently v10 系への破壊的更新に連動するため暫定許容。",
+        "reference": "https://github.com/advisories/GHSA-w7jw-789q-3m8p",
+        "expires": "2026-09-01",
+        "addedBy": "claude",
+        "addedDate": "2026-06-15"
+      }
+    ],
+    "root": [
+      {
+        "package": "esbuild",
+        "severity": "high",
+        "reason": "開発専用バンドラ (vitest/playwright等のツールチェーン経由)。devサーバが任意ファイル読取を許す (GHSA-g7r4-m6w7-qqqr)。ローカル開発時のみ起動し本番・CIランタイムに到達しない。非破壊の修正版あり (fixAvailable=true) のため次回dependabot bumpで解消予定。",
+        "reference": "https://github.com/advisories/GHSA-g7r4-m6w7-qqqr",
+        "expires": "2026-07-15",
+        "addedBy": "claude",
+        "addedDate": "2026-06-15"
+      }
+    ]
   },
   "policy": {
     "production": {


### PR DESCRIPTION
## 概要
backend向けの依存PR（dependabot）が `npm ci` の **EUSAGE（Missing @emnapi/core@1.10.0）** で全失敗していた問題の**根本原因をCI側で解消**し、あわせてセキュリティ監査のdev依存警告を整理します。

現在 #639 / #636 / #632 / #630 / #628 の5件のbackend dependabot PRがこの原因で赤化しています。

## 根本原因
- dependabotは backend の `package-lock.json` を **npm 11** で再生成する。これにより `@rolldown/binding-wasm32-wasi` 配下の **nested `@emnapi` optional依存（1.10.0）が削除**される。
- 一方 CI の backend インストールは **既定の npm 10.x** で `npm ci` していたため、生成側（npm 11）との optional依存解決差で **EUSAGE** となり、backend関連ジョブ（Build / Unit / Lint / Type / Security）が全失敗していた。
- `backend/package.json` の `packageManager` は **`npm@11.6.2`**、`backend/Dockerfile` は **corepack 経由で同npmを使用済み**。つまり **CIだけが宣言を無視**していた唯一の不整合だった。

## 変更内容
### 1. `fix(ci)`: backendの依存インストールを npm@11.6.2 に統一
- `.github/workflows/ci.yml` の backend 向け `npm ci`（matrixのbackend分岐 + 単独インストール計8箇所）を `npx -y npm@11.6.2 --prefix ... ci` に変更。frontendと同方式に揃え、生成・本番Docker・CIのnpm版を一致させる。
- **Dockerfile・本番イメージの変更は不要**（corepackで既に npm@11.6.2 を使用済み）。

#### 安全性の実機検証
`npm ci`（dry-run）を npm 11.6.2 で実行し、以下の双方が **EUSAGEなし・exit 0** を確認:
- develop現行lock（npm 10生成・nested @emnapi 保持）→ ✅
- dependabot lock（npm 11生成・nested @emnapi 欠落）→ ✅

npm 11.6.2 は両形式のlockfileを受理するため、developの赤化リスクなし。

### 2. `chore(security)`: dev専用脆弱性のallowlist整備
セキュリティ監査(strict)が警告していた dev依存のhigh/critical脆弱性を `.security-audit-allowlist.json` に理由・参照・期限付きで登録。いずれもローカル開発時のみ使用するツール由来で、CIビルド・本番ランタイムには到達しない。
- esbuild / tsx（backend, root）: devサーバの任意ファイル読取（GHSA-g7r4-m6w7-qqqr）。非破壊修正版ありのため2026-07-15期限で暫定許容。
- storybook系 / esbuild（frontend）: 同esbuild脆弱性。修正に storybook v8.6.18系への破壊的ダウングレード（現行v10）が必要なため2026-09-01期限。
- concurrently / shell-quote（frontend）: shell-quote改行未エスケープ（GHSA-w7jw-789q-3m8p）。concurrently v10系の破壊的更新が必要なため2026-09-01期限。

監査はstrictで **全workspace PASSED** を確認済み。

## マージ後の手順
このPRをdevelopにmerge後、対象5件の dependabot PR を rebase（base前進で自動、または各PRに `@dependabot rebase` コメント）すると、修正後の ci.yml で CI が再実行され緑化 → minor/patchのため auto-merge されます。

## 確認
- [x] ci.yml YAML妥当性
- [x] npm 11.6.2 での `npm ci` 整合性（develop / dependabot 双方）
- [x] セキュリティ監査 strict 全workspace PASSED
- [x] pre-push フック（フルCIパイプライン）通過
