### PR TITLE
fix(deps): frontend ws を8.21.0へbumpしメモリ枯渇脆弱性を解消

### DIFF
--- a/.security-audit-allowlist.json
+++ b/.security-audit-allowlist.json
@@ -31,9 +31,45 @@
         "expires": "2026-07-15",
         "addedBy": "claude",
         "addedDate": "2026-06-15"
+      },
+      {
+        "package": "form-data",
+        "severity": "high",
+        "reason": "開発・テスト依存経由のみ (本番依存ツリーには非該当、npm audit --omit=dev で検出されない)。multipart境界の未エスケープによるCRLFインジェクション (GHSA-hmw2-7cc7-3qxx)。本番ランタイムに影響なし。非破壊の修正版あり (fixAvailable=true) のため次回dependabot bumpで解消予定。",
+        "reference": "https://github.com/advisories/GHSA-hmw2-7cc7-3qxx",
+        "expires": "2026-07-15",
+        "addedBy": "claude",
+        "addedDate": "2026-06-15"
+      },
+      {
+        "package": "vite",
+        "severity": "high",
+        "reason": "開発専用ビルドツール (devDependency)。launch-editorのNTLMv2ハッシュ漏洩 (GHSA-v6wh-96g9-6wx3) と server.fs.deny バイパス (GHSA-fx2h-pf6j-xcff)。いずれもWindowsのdevサーバ限定で、CIビルド・本番ランタイムには到達しない。非破壊の修正版あり (fixAvailable=true) のため次回dependabot bumpで解消予定。",
+        "reference": "https://github.com/advisories/GHSA-fx2h-pf6j-xcff",
+        "expires": "2026-07-15",
+        "addedBy": "claude",
+        "addedDate": "2026-06-15"
       }
     ],
     "frontend": [
+      {
+        "package": "form-data",
+        "severity": "high",
+        "reason": "開発・テスト依存経由のみ (本番バンドル非対象)。multipart境界の未エスケープによるCRLFインジェクション (GHSA-hmw2-7cc7-3qxx)。本番ランタイムに影響なし。非破壊の修正版あり (fixAvailable=true) のため次回dependabot bumpで解消予定。",
+        "reference": "https://github.com/advisories/GHSA-hmw2-7cc7-3qxx",
+        "expires": "2026-07-15",
+        "addedBy": "claude",
+        "addedDate": "2026-06-15"
+      },
+      {
+        "package": "vite",
+        "severity": "high",
+        "reason": "開発専用ビルドツール (devDependency)。launch-editorのNTLMv2ハッシュ漏洩 (GHSA-v6wh-96g9-6wx3) と server.fs.deny バイパス (GHSA-fx2h-pf6j-xcff)。いずれもWindowsのdevサーバ限定で、本番バンドル・CIには到達しない。非破壊の修正版あり (fixAvailable=true) のため次回dependabot bumpで解消予定。",
+        "reference": "https://github.com/advisories/GHSA-fx2h-pf6j-xcff",
+        "expires": "2026-07-15",
+        "addedBy": "claude",
+        "addedDate": "2026-06-15"
+      },
       {
         "package": "storybook",
         "severity": "high",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19408,9 +19408,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "devOptional": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## 概要
新規公表された **frontend本番依存 `ws` のメモリ枯渇DoS脆弱性（GHSA-96hv-2xvq-fx4p, high）** を解消し、あわせて新規公表のdev依存警告（form-data / vite）を整理します。

#643 マージ後、この `ws` 脆弱性により **develop本体および全dependabot PR（#639/#636/#632/#630/#628）のSecurity Scan が失敗**していました（本番依存high → strict監査でブロック）。

## 根本原因
- 依存経路: `fabric@7.3.1 → jsdom@26.1.0 → ws@8.20.1`（本番依存ツリー）。
- `ws@8.20.1` に tiny fragments / data chunks によるメモリ枯渇DoS（GHSA-96hv-2xvq-fx4p）が新規公表され、脆弱範囲 `8.0.0 - 8.20.1` に該当。
- 本番依存のhighのため、`scripts/security-audit.mjs --mode=strict` がブロック（exit 1）。

## 変更内容
### 1. `fix(deps)`: frontend `ws` を 8.21.0 へbump
- `jsdom@26.1.0` は `ws ^8.18.0` を許容するため、`ws` を **8.21.0**（脆弱範囲外）へ**非破壊**でbump。
- `frontend/package-lock.json` のみ更新（差分は ws 1エントリ＝3行）。
- npm 11.6.2 で `npm ci` 整合・strict監査 **全workspace PASSED** を確認済み。

### 2. `chore(security)`: form-data / vite のdev脆弱性をallowlistへ
監査が新規公表したdev依存の警告（非ブロック）を `.security-audit-allowlist.json` に登録。いずれも開発・テスト依存経由で本番ランタイム・本番バンドルに到達しない。
- **form-data**（backend, frontend）: multipart境界の未エスケープによるCRLFインジェクション（GHSA-hmw2-7cc7-3qxx）。
- **vite**（backend, frontend）: launch-editorのNTLMv2ハッシュ漏洩（GHSA-v6wh-96g9-6wx3）/ `server.fs.deny` バイパス（GHSA-fx2h-pf6j-xcff）。Windowsのdevサーバ限定。
- いずれも非破壊の修正版ありのため **2026-07-15期限** で暫定許容（次回dependabot bumpで解消）。

## マージ後の手順
develop マージ後、5件の dependabot PR を `@dependabot rebase` で再CIすると、`ws` 修正済みdevelop上で Security Scan を含む全チェックが緑化 → minor/patch のため auto-merge されます。

## 確認
- [x] strict監査 全workspace PASSED（本番ブロック0）
- [x] npm 11.6.2 での `npm ci` 整合（frontend）
- [x] pre-push フック（フルCIパイプライン、E2E 2111 passed / 1 flaky=リトライ成功）通過
